### PR TITLE
chore: add ignore-scripts=true to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
This PR adds ignore-scripts=true to .npmrc to ensure scripts are ignored.