### PR TITLE
chore(ci): migrate from PAT to GitHub App token [SEC-58]

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -101,8 +101,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:
-          owner: rudderlabs
-          repository: rudder-devops
+          repository: rudderlabs/rudder-devops
           branch-name: rudder-looker-actions-${{ steps.version.outputs.img_version }}
           commit-message: 'chore: upgrade looker-action to ${{ steps.version.outputs.img_version }}'
           files: helm-charts/helm/looker-action-hub/environment/prod/base.yaml

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -6,19 +6,26 @@ on:
       - develop
   pull_request:
 
-permissions:
-  contents: read
-
 jobs:
   build-and-push-image:
-    permissions:
-      contents: write  # for Git to git push
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # minimal permissions for GITHUB_TOKEN
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits and push changes to devops repo
+          permission-pull-requests: write # to create PRs in devops repo
+          repositories: rudder-devops # to access rudder-devops repository
 
       - name: Check out repository code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -63,13 +70,15 @@ jobs:
 
       - name: Clone Devops Repo
         if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          git clone https://${{secrets.PAT}}@github.com/rudderlabs/rudder-devops.git
+          gh repo clone rudderlabs/rudder-devops
 
       - name: Raise PR to update image in production
         if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           cd rudder-devops
           git checkout -b rudder-looker-actions-$img_version

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -75,18 +75,36 @@ jobs:
         run: |
           gh repo clone rudderlabs/rudder-devops
 
-      - name: Raise PR to update image in production
+      - name: Get version from package.json
+        if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
+        id: version
+        run: |
+          img_version=$(jq -r .version package.json)
+          echo "img_version=$img_version" >> $GITHUB_OUTPUT
+
+      - name: Prepare devops repo changes
+        if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
+        run: |
+          cd rudder-devops/helm-charts/helm/looker-action-hub/environment/prod
+          yq eval -i ".actionhubImage.image=\"rudderstack/action-hub:${{ steps.version.outputs.img_version }}\"" base.yaml
+
+      - name: Create verified commit via GitHub API
+        if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          owner: rudderlabs
+          repository: rudder-devops
+          branch-name: rudder-looker-actions-${{ steps.version.outputs.img_version }}
+          commit-message: 'chore: upgrade looker-action to ${{ steps.version.outputs.img_version }}'
+          files: helm-charts/helm/looker-action-hub/environment/prod/base.yaml
+          working-directory: rudder-devops
+
+      - name: Create PR in devops repo
         if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           cd rudder-devops
-          git checkout -b rudder-looker-actions-$img_version
-
-          cd helm-charts/helm/looker-action-hub/environment/prod
-          yq eval -i ".actionhubImage.image=\"rudderstack/action-hub:$img_version\"" base.yaml
-          git add base.yaml
-          git commit -m "chore: upgrade looker-action to $img_version"
-          git push -u origin rudder-looker-actions-$img_version
-
           gh pr create --fill

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -63,11 +63,6 @@ jobs:
 
       # Raise PR to devops
 
-      - name: Initialize Mandatory Git Config
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "noreply@github.com"
-
       - name: Clone Devops Repo
         if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
         env:
@@ -81,6 +76,18 @@ jobs:
         run: |
           img_version=$(jq -r .version package.json)
           echo "img_version=$img_version" >> $GITHUB_OUTPUT
+
+      - name: Create release branch via GitHub API
+        if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          cd rudder-devops
+          BASE_SHA=$(git rev-parse HEAD)
+          gh api repos/rudderlabs/rudder-devops/git/refs \
+            --method POST \
+            -f ref="refs/heads/rudder-looker-actions-${{ steps.version.outputs.img_version }}" \
+            -f sha="$BASE_SHA"
 
       - name: Prepare devops repo changes
         if: ${{ github.event_name == 'push' && github.ref_name == 'master' }}


### PR DESCRIPTION
## Summary
- Migrates from PAT to GitHub App token for cross-repo operations
- Simplifies workflow by removing unnecessary git commands
- Uses GitHub API for branch creation instead of git push
- Uses ryancyq/github-signed-commit for verified commits

### Migration Pattern Evolution
1. The signed-commit action (`ryancyq/github-signed-commit`) creates commits via GitHub's GraphQL API, producing **verified commits** with the App's identity
2. This eliminates the need for many git commands: `git config`, `git add`, `git commit`, `git push`
3. The key insight is that branches must be created via GitHub API (`gh api .../git/refs`) before the signed-commit action can push to them

### Migration Details

| File | Changes Made |
|------|-------------|
| build-and-push-docker-image.yml | ✅ Removed `git config user.name/email` (no longer needed with API commits)<br>✅ Replaced `git checkout -b` + `git push` with `gh api .../git/refs` (API-based branch creation)<br>✅ Uses `ryancyq/github-signed-commit` for verified commits via GitHub API<br>✅ GitHub App token generated early in the workflow |

### Technical Changes

**Removed (no longer needed):**
- `git config user.name "GitHub Actions"` - signed-commit uses App identity
- `git config user.email noreply@github.com` - signed-commit uses App identity
- `git checkout -b $branch_name` followed by `git push` - replaced with API branch creation

**Added:**
- `gh api repos/rudderlabs/rudder-devops/git/refs` - creates branch via GitHub API
- Branch creation happens before signed-commit action runs

### Why These Changes

1. **API-based branch creation**: Creates branches cleanly without needing to embed tokens in git URLs
2. **Verified commits**: The signed-commit action uses GitHub's GraphQL API, producing commits verified by the GitHub App
3. **Cleaner code**: Fewer git commands = simpler, more maintainable workflow
4. **Security**: No need to manipulate git remote URLs with tokens

## Test plan
- [ ] Verify workflow runs successfully when pushing to master
- [ ] Verify devops repo PR is created with verified commit
- [ ] Check that the commit appears as "Verified" in GitHub UI

## References
- Migration plan: /Users/leonidas/.graft/cache/repos/rudderlabs/PAT_MIGRATION_AGENT_PLAN.md
- Signed commit pattern (lines 440-560)

🤖 Generated with [Claude Code](https://claude.com/claude-code)